### PR TITLE
Pin Coverlet.collector to 6.0.4

### DIFF
--- a/Tests/FluentAssertions.DataSets.Specs/FluentAssertions.DataSets.Specs.csproj
+++ b/Tests/FluentAssertions.DataSets.Specs/FluentAssertions.DataSets.Specs.csproj
@@ -20,7 +20,7 @@
   <ItemGroup>
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="System.Data.DataSetExtensions" Version="4.5.0" />
-    <PackageReference Include="coverlet.collector" Version="6.0.4" PrivateAssets="all">
+    <PackageReference Include="coverlet.collector" Version="[6.0.4]" PrivateAssets="all">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
   </ItemGroup>


### PR DESCRIPTION
<!-- Please provide a description of your changes above the IMPORTANT checklist -->

Coverlet.collector 8+ requires .NET 8+
See https://github.com/coverlet-coverage/coverlet/issues/1842

This overrides #119

## IMPORTANT 

* [ ] If the PR touches the public API, the changes have been approved in a separate issue with the "api-approved" label.
* [ ] The code complies with the [Coding Guidelines for C#](https://www.csharpcodingguidelines.com/).
* [ ] The changes are covered by unit tests which follow the Arrange-Act-Assert syntax and the naming conventions such as is used [in these tests](../tree/develop/Tests/FluentAssertions.Equivalency.Specs/MemberMatchingSpecs.cs#L51-L430).
* [ ] If the PR changes the public API the changes needs to be included by running [AcceptApiChanges.ps1](../tree/develop/AcceptApiChanges.ps1) or [AcceptApiChanges.sh](../tree/develop/AcceptApiChanges.sh).
