### PR TITLE
Change Dependabot schedule to monthly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,7 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
       day: "monday"
       time: "16:00"
       timezone: "Europe/Copenhagen"
@@ -11,7 +11,7 @@ updates:
   - package-ecosystem: "nuget"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
       day: "monday"
       time: "16:00"
       timezone: "Europe/Copenhagen"


### PR DESCRIPTION
Updates `.github/dependabot.yml` so both the `github-actions` and `nuget` update checks run `monthly` instead of `weekly`.